### PR TITLE
Add gitignore for Python artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc


### PR DESCRIPTION
## Summary
- add `.gitignore` to ignore `__pycache__/` and `*.pyc`

## Testing
- `python -m py_compile nodeseek_sign.py notify.py turnstile_solver.py yescaptcha.py`


------
https://chatgpt.com/codex/tasks/task_e_687a349adb188333b23c2e0f87c6bbc6